### PR TITLE
padroniza nome das funçoes 

### DIFF
--- a/src/controllers/evaluation/index.ts
+++ b/src/controllers/evaluation/index.ts
@@ -1,7 +1,7 @@
 import { Evaluation } from "@models/entity/Evaluation"
 import { getRepository } from "typeorm"
 
-export const getEvaluations = async (request, response) => {
+export const getAllEvaluation = async (request, response) => {
   const { page = 0, count = 50 } = request.query
   const evaluationRepository = getRepository(Evaluation)
   const evaluations = await evaluationRepository.find({ skip: page, take: count })

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -17,7 +17,7 @@ import {
   patchExercise
 } from '@controllers/exercise'
 import { importExercises } from '@controllers/exercise'
-import { getEvaluation, getEvaluations } from '@controllers/evaluation'
+import { getEvaluation, getAllEvaluation } from '@controllers/evaluation'
 
 export const defineRoutes = (app) => {
   app.get('/', itsWorks)
@@ -32,7 +32,7 @@ export const defineRoutes = (app) => {
   app.get('/candidate/exercise/hiring_process/:id', exportHiringProcessResume)
   app.post('/candidate/hiring_process/:id', importAllCandidate)
 
-  app.get('/evaluation', getEvaluations)
+  app.get('/evaluation', getAllEvaluation)
   app.get('/evaluation/:id', getEvaluation)
 
   app.get('/exercise', getExerciseByHiringProcessId)


### PR DESCRIPTION
#108 - refact: padronização dos prefixos das funções - controllers/evaluation
====
  
### 🆙 CHANGELOG

- Mudança do nome da função getEvatualtions para getAllEvaluation
- Alteração dos nomes no arquivo routes

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:
- [x] Abrir URL da aplicação de teste no postman : Acessar o link https://eluvya-acelera-mais-api-teste.herokuapp.com/
- [x] Dar GET no https://eluvya-acelera-mais-api-teste.herokuapp.com/evaluation
- [x] Verificar se retorna a lista com todas as avaliações
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
