### PR TITLE
refact: padronização dos prefixos das funções - controllers/exercise

### DIFF
--- a/src/controllers/exercise/index.ts
+++ b/src/controllers/exercise/index.ts
@@ -23,7 +23,7 @@ export const createEvaluation = async (request, response) => {
   }
 }
 
-export const editEvaluation = async (request, response) => {
+export const updateEvaluation = async (request, response) => {
   try {
     const { mentorName, score, feedback } = request.body
     const { id } = request.params
@@ -83,7 +83,7 @@ const mapExercises = (id) => {
   }
 }
 
-export const importExercises = async (request, response) => {
+export const importAllExercise = async (request, response) => {
   try {
     const { id } = request.params
     const { link } = request.body
@@ -117,7 +117,7 @@ export const importExercises = async (request, response) => {
       return result
     })
 
-    return httpResponseHandler.createSuccessResponse(message.SUCCESS, { id, exercises, count:exercisesSheet.length  }, response)
+    return httpResponseHandler.createSuccessResponse(message.SUCCESS, { id, exercises, count: exercisesSheet.length }, response)
   } catch (error) {
     return httpResponseHandler.createErrorResponse(error, response)
   }
@@ -154,7 +154,7 @@ export const getExerciseById = async (request, response) => {
   }
 }
 
-export const patchExercise = async (request, response) => {
+export const updateExercise = async (request, response) => {
   const { id } = request.params
   const { type } = request.body
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -9,14 +9,14 @@ import {
 import { getCandidate, getAllCandidate, importAllCandidate } from '@controllers/candidate'
 import {
   createEvaluation,
-  editEvaluation,
+  updateEvaluation,
   deleteEvaluation,
   getExerciseById,
   getExerciseByHiringProcessId,
   exportHiringProcessResume,
-  patchExercise
+  updateExercise
 } from '@controllers/exercise'
-import { importExercises } from '@controllers/exercise'
+import { importAllExercise } from '@controllers/exercise'
 import { getEvaluation, getEvaluations } from '@controllers/evaluation'
 
 export const defineRoutes = (app) => {
@@ -38,9 +38,9 @@ export const defineRoutes = (app) => {
   app.get('/exercise', getExerciseByHiringProcessId)
   app.get('/exercise/:id', getExerciseById)
   app.post('/exercise', createEvaluation)
-  app.patch('/exercise/:id', patchExercise)
-  app.post('/exercise/hiring_process/:id', importExercises)
+  app.patch('/exercise/:id', updateExercise)
+  app.post('/exercise/hiring_process/:id', importAllExercise)
   app.delete('/exercise/:id', deleteEvaluation)
 
-  app.patch('/evaluation/:id', editEvaluation)
+  app.patch('/evaluation/:id', updateEvaluation)
 }


### PR DESCRIPTION
#109  - refact: padronização dos prefixos das funções - controllers/exercise
====
  
### 🆙 CHANGELOG

- Mudança no nome das funções patchExercise para updateExercise, importExercises para importAllExercise e editEvaluation para updateEvaluation

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

Para testar o importAllExercise:
- [x]  Abrir o Postman e colocar o link da URL de teste https://esther-acelera-mais-api.herokuapp.com/ com endpoint "/exercise/hiring_process/:id"
- [x] Ainda no postman, usar o método POST (Body, x-www-form-urlencoded), adicionar no key "link" e no value "https://docs.google.com/spreadsheets/d/1Xn-fcGHuyx4TxzMCqTJ7gmKcMbMdNWR6CBtRHr2v84M/edit#gid=1886435917"
 image
- [x] Deve retornar mensagem "Salvo com sucesso", e verificar se apareceu a listagem dos exercícios

Para testar o updateExercise:
- [x]  Abrir o Postman e colocar o link da URL de teste https://esther-acelera-mais-api.herokuapp.com/
- [x] Dar um PATCH com a rota exercise/:id 
- [x] No Body do Postman, no campo x-www-form-urlencoded, insira no campo KEY: type e no VALUE: Front, Backend ou Fullstack.
- [x] Verificar se trouxe as mensagem "Atualizado com sucesso!" com status 200, e o campo type modificado conforme o VALUE que você escreveu.

Para testar o updateEvaluation:
- [x]  Abrir o Postman e colocar o link da URL de teste https://esther-acelera-mais-api.herokuapp.com/ com endpoint /exercise. 
- [x]  No Postman, selecione o método POST para criar novo exercício;
- [x] Deve seguir as exigência no BODY como "mentorName" "feedback" "score" dessa maneira escrita, um em cada parte da key, para poder utilzar.

Confirmo que:
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
