### PR TITLE
103/refact move funções do escopo de evaluation para arquio correto

### DIFF
--- a/src/controllers/evaluation/index.ts
+++ b/src/controllers/evaluation/index.ts
@@ -1,5 +1,9 @@
 import { Evaluation } from "@models/entity/Evaluation"
 import { getRepository } from "typeorm"
+import { EvaluationRequest } from '@service/exercise/EvaluationRequest'
+import { EvaluationService } from '@service/exercise/EvaluationService'
+import { HttpResponseHandler } from "@controllers/HttpResponseHandler"
+import { message } from "@messages/languages/pt-br"
 
 export const getAllEvaluation = async (request, response) => {
   const { page = 0, count = 50 } = request.query
@@ -13,4 +17,42 @@ export const getEvaluation = async (request, response) => {
   const evaluationRepository = getRepository(Evaluation)
   const evaluation = await evaluationRepository.findOne(id)
   return response.json({ evaluation })
+}
+
+const httpResponseHandler = new HttpResponseHandler()
+const evaluationService = new EvaluationService()
+
+export const createEvaluation = async (request, response) => {
+  try {
+    const evaluationRequest = EvaluationRequest.convertFromHttpBody(request.body)
+    const result = await evaluationService.createEvaluationService(evaluationRequest)
+    return httpResponseHandler.createSuccessResponse(message.SUCCESS, result, response)
+  } catch (error) {
+    return httpResponseHandler.createErrorResponse(error, response)
+  }
+}
+
+export const updateEvaluation = async (request, response) => {
+  try {
+    const { mentorName, score, feedback } = request.body
+    const { id } = request.params
+    const evaluationUpdated = await evaluationService.editEvaluation(
+      id,
+      mentorName,
+      score,
+      feedback)
+    return httpResponseHandler.createSuccessResponse(message.UPDATED, evaluationUpdated, response)
+  } catch (error) {
+    console.log(error)
+    return httpResponseHandler.createErrorResponse(error, response)
+  }
+}
+
+export const deleteEvaluation = async (request, response) => {
+  try {
+    const result = await evaluationService.deleteEvaluation(request.params.id)
+    return httpResponseHandler.createSuccessResponse(message.REMOVED, result, response)
+  } catch (error) {
+    return httpResponseHandler.createErrorResponse(error, response)
+  }
 }

--- a/src/controllers/evaluation/index.ts
+++ b/src/controllers/evaluation/index.ts
@@ -5,6 +5,9 @@ import { EvaluationService } from '@service/exercise/EvaluationService'
 import { HttpResponseHandler } from "@controllers/HttpResponseHandler"
 import { message } from "@messages/languages/pt-br"
 
+const httpResponseHandler = new HttpResponseHandler()
+const evaluationService = new EvaluationService()
+
 export const getAllEvaluation = async (request, response) => {
   const { page = 0, count = 50 } = request.query
   const evaluationRepository = getRepository(Evaluation)
@@ -18,9 +21,6 @@ export const getEvaluation = async (request, response) => {
   const evaluation = await evaluationRepository.findOne(id)
   return response.json({ evaluation })
 }
-
-const httpResponseHandler = new HttpResponseHandler()
-const evaluationService = new EvaluationService()
 
 export const createEvaluation = async (request, response) => {
   try {

--- a/src/controllers/exercise/index.ts
+++ b/src/controllers/exercise/index.ts
@@ -6,8 +6,6 @@ import { importSpreadSheet } from "@service/google-spreadsheet"
 import { ExerciseService } from "@service/exercise/ExerciseService"
 import { Evaluation } from '@models/entity/Evaluation'
 
-
-
 const httpResponseHandler = new HttpResponseHandler()
 const exerciseService = new ExerciseService()
 

--- a/src/controllers/exercise/index.ts
+++ b/src/controllers/exercise/index.ts
@@ -1,5 +1,3 @@
-import { EvaluationRequest } from '@service/exercise/EvaluationRequest'
-import { EvaluationService } from '@service/exercise/EvaluationService'
 import { HttpResponseHandler } from "@controllers/HttpResponseHandler"
 import { message } from "@messages/languages/pt-br"
 import { Exercise } from "@models/entity/Exercise"
@@ -9,44 +7,9 @@ import { ExerciseService } from "@service/exercise/ExerciseService"
 import { Evaluation } from '@models/entity/Evaluation'
 
 
-const evaluationService = new EvaluationService()
+
 const httpResponseHandler = new HttpResponseHandler()
 const exerciseService = new ExerciseService()
-
-export const createEvaluation = async (request, response) => {
-  try {
-    const evaluationRequest = EvaluationRequest.convertFromHttpBody(request.body)
-    const result = await evaluationService.createEvaluationService(evaluationRequest)
-    return httpResponseHandler.createSuccessResponse(message.SUCCESS, result, response)
-  } catch (error) {
-    return httpResponseHandler.createErrorResponse(error, response)
-  }
-}
-
-export const updateEvaluation = async (request, response) => {
-  try {
-    const { mentorName, score, feedback } = request.body
-    const { id } = request.params
-    const evaluationUpdated = await evaluationService.editEvaluation(
-      id,
-      mentorName,
-      score,
-      feedback)
-    return httpResponseHandler.createSuccessResponse(message.UPDATED, evaluationUpdated, response)
-  } catch (error) {
-    console.log(error)
-    return httpResponseHandler.createErrorResponse(error, response)
-  }
-}
-
-export const deleteEvaluation = async (request, response) => {
-  try {
-    const result = await evaluationService.deleteEvaluation(request.params.id)
-    return httpResponseHandler.createSuccessResponse(message.REMOVED, result, response)
-  } catch (error) {
-    return httpResponseHandler.createErrorResponse(error, response)
-  }
-}
 
 const mapExercises = (id) => {
 


### PR DESCRIPTION
#103  - refact: mover funções do escopo de evaluation para arquivo correto
====
  
### 🆙 CHANGELOG

- As funções `createEvaluation`, `updateEvaluation` e `deleteEvaluation` foram movidas para a controller correta

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Abrir o Postman e colocar o link da URL https://eluvya-acelera-mais-api-teste.herokuapp.com/exercise/
- [ ] Selecione o método POST para criar novo exercício; 
- [ ] Deve seguir as exigência no BODY como "mentorName" "feedback" "score" dessa maneira escrita, um em cada parte da key, para poder utilizar.
- [ ] Em seguida, selecione método PATCH para editar o exercício criado anteriormente.
- [ ] Para deletar a avaliação, selecionar o método DELETE e clicar em send.
- [ ] Verificar se foi removido com sucesso.
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
