### PR TITLE
121/refact: remover classe e transformar em função Service/ExerciseService

### DIFF
--- a/src/controllers/exercise/index.ts
+++ b/src/controllers/exercise/index.ts
@@ -3,11 +3,11 @@ import { message } from "@messages/languages/pt-br"
 import { Exercise } from "@models/entity/Exercise"
 import { getRepository } from "typeorm"
 import { importSpreadSheet } from "@service/google-spreadsheet"
-import { ExerciseService } from "@service/exercise/ExerciseService"
+import { exerciseService } from "@service/exercise/ExerciseService"
 import { Evaluation } from '@models/entity/Evaluation'
 
 const httpResponse = httpResponseHandler()
-const exerciseService = new ExerciseService()
+const allExercises = exerciseService()
 
 const mapExercises = (id) => {
 
@@ -93,7 +93,7 @@ export const exportHiringProcessResume = async (req, res) => {
 export const getExerciseByHiringProcessId = async (req, res) => {
   const { page, count, hiringProcessId, type, feedback } = req.query
   try {
-    const result = await exerciseService.getAllExercises({ page, count, hiringProcessId, type })
+    const result = await allExercises.getAllExercises({ page, count, hiringProcessId, type })
     return httpResponse.createSuccessResponse(message.FOUND, { hiringProcessId, result }, res)
   }
   catch (error) {

--- a/src/service/exercise/ExerciseService.ts
+++ b/src/service/exercise/ExerciseService.ts
@@ -3,28 +3,11 @@ import { Exercise } from "@models/entity/Exercise"
 import { HttpError, HttpStatusCode } from "@service/HttpError"
 import { getRepository } from "typeorm"
 
-// export class ExerciseService {
-//   public async getAllExercises({ page, count, hiringProcessId, type }) {
-//     let where = { hiringProcess: hiringProcessId }
-//     if (type) { where = { ...where, type } }
-//     const exerciseRepository = getRepository(Exercise)
-//     const result = await exerciseRepository.find({
-//       where,
-//       skip: page,
-//       take: count
-//     })
-//     if (result.length === 0) {
-//       throw new HttpError(message.NOT_FOUND, HttpStatusCode.NOT_FOUND)
-//     }
-//     return result
-//   }
-// }
-
 export const exerciseService = () => {
 
   const getAllExercises = async ({ page, count, hiringProcessId, type }) => {
     let where = { hiringProcess: hiringProcessId }
-    if (type) { where = { ...where, type } }
+    if (type) { where = { ...where, ...type } }
     const exerciseRepository = getRepository(Exercise)
     const result = await exerciseRepository.find({
       where,

--- a/src/service/exercise/ExerciseService.ts
+++ b/src/service/exercise/ExerciseService.ts
@@ -7,7 +7,7 @@ export const exerciseService = () => {
 
   const getAllExercises = async ({ page, count, hiringProcessId, type }) => {
     let where = { hiringProcess: hiringProcessId }
-    if (type) { where = { ...where, ...type } }
+    if (type) { where = { ...where, type } }
     const exerciseRepository = getRepository(Exercise)
     const result = await exerciseRepository.find({
       where,

--- a/src/service/exercise/ExerciseService.ts
+++ b/src/service/exercise/ExerciseService.ts
@@ -3,8 +3,26 @@ import { Exercise } from "@models/entity/Exercise"
 import { HttpError, HttpStatusCode } from "@service/HttpError"
 import { getRepository } from "typeorm"
 
-export class ExerciseService {
-  public async getAllExercises({ page, count, hiringProcessId, type }) {
+// export class ExerciseService {
+//   public async getAllExercises({ page, count, hiringProcessId, type }) {
+//     let where = { hiringProcess: hiringProcessId }
+//     if (type) { where = { ...where, type } }
+//     const exerciseRepository = getRepository(Exercise)
+//     const result = await exerciseRepository.find({
+//       where,
+//       skip: page,
+//       take: count
+//     })
+//     if (result.length === 0) {
+//       throw new HttpError(message.NOT_FOUND, HttpStatusCode.NOT_FOUND)
+//     }
+//     return result
+//   }
+// }
+
+export const exerciseService = () => {
+
+  const getAllExercises = async ({ page, count, hiringProcessId, type }) => {
     let where = { hiringProcess: hiringProcessId }
     if (type) { where = { ...where, type } }
     const exerciseRepository = getRepository(Exercise)
@@ -18,4 +36,6 @@ export class ExerciseService {
     }
     return result
   }
+
+  return { getAllExercises }
 }


### PR DESCRIPTION
#121 - refact: remover classe e transformar em função Service/ExerciseService
====
  
### 🆙 CHANGELOG

- A classe ExerciseService foi transformada na função exerciseService, através do padrão Factory
- Essa mudança resultou em correções de importação no arquivo controllers/exercise/index.js

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [x] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Abrir link de teste: https://esther-acelera-mais.herokuapp.com/ 
- [x] Fazer login na aplicação (email: ju@gmail.com, senha: 123456)
- [x] Entrar em algum dos processos seletivos
- [x] Verificar se a tela com os exercícios aparece corretamente
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
