### PR TITLE
145/Endpoint de cadastro de mentoras: DELETE

### DIFF
--- a/src/controllers/user/index.ts
+++ b/src/controllers/user/index.ts
@@ -1,7 +1,9 @@
 import { httpResponseHandler } from "@controllers/HttpResponseHandler"
 import { message } from "@messages/languages/pt-br"
+import { User } from "@models/entity/User"
 import { userRequest } from "@service/user/UserRequest"
 import { userService } from "@service/user/UserService"
+import { getRepository } from "typeorm"
 
 
 export const createUser = async (request, response) => {
@@ -11,5 +13,18 @@ export const createUser = async (request, response) => {
     return httpResponseHandler().createSuccessResponse(message.SUCCESS, result, response)
   } catch (error) {
     return httpResponseHandler().createErrorResponse(error, response)
+  }
+}
+
+export const deleteUser = async (request, response) => {
+  try {
+    const UserRepository = getRepository(User)
+    const result = await UserRepository.delete(request.params.id)
+    if (result.affected === 0) {
+      return response.status(410).json({ message: message.NOT_REMOVED })
+    }
+    return response.json({ message: message.REMOVED, result })
+  } catch (error) {
+    return response.status(500).json(error)
   }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -20,7 +20,7 @@ import {
 } from '@controllers/evaluation'
 import { importAllChallenge } from '@controllers/challenge'
 import { getEvaluation, getAllEvaluation } from '@controllers/evaluation'
-import { createUser } from '@controllers/user'
+import { createUser, deleteUser } from '@controllers/user'
 import { format } from 'path/posix'
 
 
@@ -49,4 +49,5 @@ export const defineRoutes = (app) => {
   app.post('/challenge/hiring_process/:id', importAllChallenge)
 
   app.post('/user', createUser)
+  app.delete('/user/:id', deleteUser)
 }


### PR DESCRIPTION
#145  - Endpoint de cadastro de mentoras: DELETE
====
  
### 🆙 CHANGELOG

- Cria função `deleteUser` em `controllers/user`

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [x] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Abra o postman
- [x] Insira a url http://leo-acelera-mais-api.herokuapp.com/user e selecione a ação DELETE
- [x] Na url, insira um ID após o `/user`, por exemplo: http://leo-acelera-mais-api.herokuapp.com/user/30
- [x] Realize a ação de DELETE
- [x] Verifique se em caso de sucesso é retornado o status 200 OK
- [x] Tente deletar o mesmo ID novamente
- [x] Verifique se em caso de falha é retornado o status 410 GONE
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
