### PR TITLE
Login: forçar troca de senha

### DIFF
--- a/src/service/Flags.ts
+++ b/src/service/Flags.ts
@@ -1,0 +1,5 @@
+export const flags = {
+  FIRST_LOGIN: "first-login",
+  USER_ENABLED: "user-enabled",
+  USER_DISABLED: "user-disabled",
+}

--- a/src/service/Flags.ts
+++ b/src/service/Flags.ts
@@ -1,5 +1,5 @@
-export const flags = {
-  FIRST_LOGIN: "first-login",
-  USER_ENABLED: "user-enabled",
-  USER_DISABLED: "user-disabled",
+export enum UserRegistrationStatus {
+  FIRST_LOGIN = "first-login",
+  USER_ENABLED = "user-enabled",
+  USER_DISABLED = "user-disabled",
 }

--- a/src/service/auth/AuthService.ts
+++ b/src/service/auth/AuthService.ts
@@ -1,3 +1,4 @@
+import { flags } from "@service/Flags"
 import { HttpError, HttpStatusCode } from "../HttpError"
 import { findUserByEmail } from "./AuthRequest"
 
@@ -5,6 +6,7 @@ const jwt = require("jsonwebtoken")
 
 export const createAccessToken = async (emailUser, passwordUser) => {
   const { SECRET, NODEMAILER_SECRET } = process.env
+  let auth = true
 
   const encodePassword = jwt.sign(passwordUser, NODEMAILER_SECRET)
 
@@ -14,11 +16,15 @@ export const createAccessToken = async (emailUser, passwordUser) => {
     throw new HttpError("Unauthorized", HttpStatusCode.UNAUTHORIZED)
   }
 
+  if (user.flag.includes(flags.FIRST_LOGIN)) {
+    auth = false
+  }
+
   const payload = { name: user.name, email: user.email, role: user.type }
   const accessToken = jwt.sign(payload, SECRET)
 
   return {
-    auth: true,
+    auth,
     accessToken,
     user: payload,
   }

--- a/src/service/auth/AuthService.ts
+++ b/src/service/auth/AuthService.ts
@@ -1,4 +1,4 @@
-import { flags } from "@service/Flags"
+import { UserRegistrationStatus } from "@service/Flags"
 import { HttpError, HttpStatusCode } from "../HttpError"
 import { findUserByEmail } from "./AuthRequest"
 
@@ -16,7 +16,7 @@ export const createAccessToken = async (emailUser, passwordUser) => {
     throw new HttpError("Unauthorized", HttpStatusCode.UNAUTHORIZED)
   }
 
-  if (user.flag.includes(flags.FIRST_LOGIN)) {
+  if (user.flag.includes(UserRegistrationStatus.FIRST_LOGIN)) {
     auth = false
   }
 


### PR DESCRIPTION
#164 - Login: forçar troca de senha
====
  
### 🆙 CHANGELOG

- Implementa nova verificação para forçar o usuário a trocar a senha no primeiro acesso

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Abra o link https://leo-acelera-mais-front.herokuapp.com/
- [x] Faça login com o usuário willianchris89@gmail.com e a senha 0ptduyrdwg
  - Este usuário tem o campo `flag` definido como 'first-login', ele deverá ser redirecionado para a url `/password-reset`
- [x] Faça login com o usuário leonardogomespadilha@gmail.com e a senha 8ms68b3k7a
  - Este usuário deverá ser redirecionado para a url `/home`
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
