### PR TITLE
Refactor: Added the challenge adapter to the back-end

### DIFF
--- a/src/service/challenge/adapter/ChallengeAdapter.ts
+++ b/src/service/challenge/adapter/ChallengeAdapter.ts
@@ -1,0 +1,32 @@
+const mapExercises = (exercises) => {
+  return exercises.map((exercise) => {
+    return {
+      idExercise: exercise.id,
+      evaluation: {
+        id: exercise.evaluation.id,
+        mentorName: exercise.evaluation.mentorName,
+        feedback: exercise.evaluation.feedback,
+        score: exercise.evaluation.score,
+      },
+      name: exercise.name,
+      exerciseType: exercise.exerciseType,
+      link: exercise.link,
+    }
+  })
+}
+export const challengesAdapter = (challenges) => {
+  const challengesMapped = challenges.map((c) => {
+    const { id, type, exercises } = c
+    const exercisesMapped = mapExercises(exercises)
+    return exercisesMapped.map((exercise) => {
+      return { id, type, ...exercise }
+    })
+  })
+  const exercisesMapped = []
+  challengesMapped.forEach((challenge) => {
+    challenge.forEach((exercise) => {
+      exercisesMapped.push(exercise)
+    })
+  })
+  return exercisesMapped
+}


### PR DESCRIPTION
#205 - Refatoração: Eliminar adapter do front-end no endpoint de challenges
====
  
### 🆙 CHANGELOG

*Esses passos são apenas exemplos*

- Excluida a pasta adapter dentro da pasta challenges no front-end
- Criada a pasta adapter dentro da pasta challenges no back-end
- Adicionado o arquivo adapter de challenge dentro do back-end

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Acessar https://enzo-acelera-mais-api.herokuapp.com/
- [ ] Abrir URL da aplicação de teste
- [ ] Verificar modificação 1
- [ ] Verificar modificação 2
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
