### PR TITLE
229/bug import nao tras exercicio

### DIFF
--- a/src/controllers/candidate/index.ts
+++ b/src/controllers/candidate/index.ts
@@ -9,7 +9,6 @@ const responseHandle = httpResponseHandler()
 
 const mapCandidates = (id) => {
   const normaliseDate = (date) => {
-    return date
     const newDate = date.split("/")
     return `${newDate[1]}/${newDate[0]}/${newDate[2]}`
   }
@@ -22,7 +21,6 @@ const mapCandidates = (id) => {
       const challenge = new Challenge()
       challenge.hiringProcess = id
       challenge.addressEmail = email
-      console.log(r["Você possui algum desses equipamentos ?"])
       return {
         hiringProcess: { id: parseInt(id) },
         challenge,

--- a/src/controllers/candidate/index.ts
+++ b/src/controllers/candidate/index.ts
@@ -9,6 +9,7 @@ const responseHandle = httpResponseHandler()
 
 const mapCandidates = (id) => {
   const normaliseDate = (date) => {
+    return date
     const newDate = date.split("/")
     return `${newDate[1]}/${newDate[0]}/${newDate[2]}`
   }
@@ -21,7 +22,7 @@ const mapCandidates = (id) => {
       const challenge = new Challenge()
       challenge.hiringProcess = id
       challenge.addressEmail = email
-
+      console.log(r["Você possui algum desses equipamentos ?"])
       return {
         hiringProcess: { id: parseInt(id) },
         challenge,

--- a/src/controllers/challenge/index.ts
+++ b/src/controllers/challenge/index.ts
@@ -43,7 +43,8 @@ const mapChallenges = (id) => {
             "Você se incomodaria em abrir sua Webcam durante as interações quanto a Aceleradora Ágil?"
           ],
         exerciseStatement: r["Enunciado dos exercícios"],
-        type: r["Você desenvolveu o exercício com:"],
+        type: "", 
+        exerciseType: r["Você desenvolveu o exercício com:"],
         hiringProcess: { id },
       }
     })
@@ -92,7 +93,7 @@ const groupChallengesByEmail = ({ challenges }) => {
         type: typeAndLink.type,
         link: typeAndLink.link,
         exerciseStatement: obj.exerciseStatement,
-        exerciseType: "",
+        exerciseType: obj.exerciseType,
       })
     )
     return acc
@@ -142,7 +143,7 @@ export const importAllChallenge = async (request, response) => {
         hiringProcess,
         exercises,
         exerciseStatement,
-        type,
+        exerciseType,
       } = data
 
       const newChallenge = await challengeRepository.findOne({
@@ -168,7 +169,7 @@ export const importAllChallenge = async (request, response) => {
         newChallenge.cityState = cityState
         newChallenge.exercises = exercises
         newChallenge.exerciseStatement = exerciseStatement
-        newChallenge.type = type
+        newChallenge.exerciseType = exerciseType
         return await challengeRepository.save(newChallenge)
       }
 

--- a/src/controllers/challenge/index.ts
+++ b/src/controllers/challenge/index.ts
@@ -14,6 +14,7 @@ const httpResponse = httpResponseHandler()
 
 const mapChallenges = (id) => {
   const normaliseDate = (date) => {
+    return date
     const newDate = date.split("/")
     return `${newDate[1]}/${newDate[0]}/${newDate[2]}`
   }
@@ -21,7 +22,7 @@ const mapChallenges = (id) => {
   return (rows) => {
     return rows.map((r) => {
       const timeStamp = normaliseDate(r["Carimbo de data/hora"])
-
+      console.log(r["Você desenvolveu o exercício com:"])
       return {
         timeStamp,
         addressEmail: r["Endereço de e-mail"],
@@ -42,7 +43,7 @@ const mapChallenges = (id) => {
             "Você se incomodaria em abrir sua Webcam durante as interações quanto a Aceleradora Ágil?"
           ],
         exerciseStatement: r["Enunciado dos exercícios"],
-        type: "",
+        type: r["Você desenvolveu o exercício com:"],
         hiringProcess: { id },
       }
     })
@@ -60,11 +61,18 @@ const getExerciseType = (challenge) => {
   return { type: "Not defined.", link: "" }
 }
 
-const createExercise = ({ name, type, link, exerciseStatement }) => {
+const createExercise = ({
+  name,
+  type,
+  link,
+  exerciseStatement,
+  exerciseType,
+}) => {
   const exercise = new Exercise()
   exercise.name = name
   exercise.type = type
   exercise.link = link
+  exercise.exerciseType = exerciseType
   exercise.exerciseStatement = exerciseStatement
   exercise.evaluation = new Evaluation()
   return exercise
@@ -84,6 +92,7 @@ const groupChallengesByEmail = ({ challenges }) => {
         type: typeAndLink.type,
         link: typeAndLink.link,
         exerciseStatement: obj.exerciseStatement,
+        exerciseType: "",
       })
     )
     return acc
@@ -133,6 +142,7 @@ export const importAllChallenge = async (request, response) => {
         hiringProcess,
         exercises,
         exerciseStatement,
+        type,
       } = data
 
       const newChallenge = await challengeRepository.findOne({
@@ -158,6 +168,7 @@ export const importAllChallenge = async (request, response) => {
         newChallenge.cityState = cityState
         newChallenge.exercises = exercises
         newChallenge.exerciseStatement = exerciseStatement
+        newChallenge.type = type
         return await challengeRepository.save(newChallenge)
       }
 

--- a/src/controllers/challenge/index.ts
+++ b/src/controllers/challenge/index.ts
@@ -14,7 +14,6 @@ const httpResponse = httpResponseHandler()
 
 const mapChallenges = (id) => {
   const normaliseDate = (date) => {
-    return date
     const newDate = date.split("/")
     return `${newDate[1]}/${newDate[0]}/${newDate[2]}`
   }
@@ -22,7 +21,6 @@ const mapChallenges = (id) => {
   return (rows) => {
     return rows.map((r) => {
       const timeStamp = normaliseDate(r["Carimbo de data/hora"])
-      console.log(r["Você desenvolveu o exercício com:"])
       return {
         timeStamp,
         addressEmail: r["Endereço de e-mail"],
@@ -43,7 +41,7 @@ const mapChallenges = (id) => {
             "Você se incomodaria em abrir sua Webcam durante as interações quanto a Aceleradora Ágil?"
           ],
         exerciseStatement: r["Enunciado dos exercícios"],
-        type: "", 
+        type: "",
         exerciseType: r["Você desenvolveu o exercício com:"],
         hiringProcess: { id },
       }

--- a/src/models/entity/Challenge.ts
+++ b/src/models/entity/Challenge.ts
@@ -64,6 +64,9 @@ export class Challenge {
   @Column({ name: 'exercise_statement', nullable: true, type: 'varchar' })
   exerciseStatement: string;
 
+  @Column({ name: 'exercise_type', nullable: true, type: 'varchar' })
+  exerciseType: string;
+
   @Column({ name: 'city_state', nullable: true, type: 'varchar' })
   cityState: string;
 


### PR DESCRIPTION
#229 - Bug: Import não traz tipo do exercício
====
  
### 🆙 CHANGELOG

- Nas models Exercise e Challenge foi adicionado a coluna exerciseType
- No arquivo index.ts no caminho `'src/controllers/challenge'` foi adicionado o campo exerciseType no return da função mapChallenges
- No mesmo arquivo anterior, na função createExercise foi adicionado a variável exercise.exerciseType, juntamente da função groupChallengeByEmail.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [x] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Fazer deploy da branch 229/bug-import-nao-tras-exercicio no back-end
- [x] Acessar os arquivos com a função `'normailseDate'`
- [x] Nessas funções colocar para retornar apenas date
- [x] Executar o sistema
- [x] Fazer o login com um usuário local
- [x] Acessar a etapa de processos seletivos
- [x] Criar um processo seletivo de maneira normal
- [x] Inserir as planilhas com os links de candidatas e desafios
- [x] Abrir o processo seletivo
- [x] Verificar se o campo tipo possui um tipo definido
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
